### PR TITLE
Ceph mds dump and friends don't work anymore since Ceph Mimic release…

### DIFF
--- a/ceph-collect
+++ b/ceph-collect
@@ -129,9 +129,7 @@ def get_osd_info(r, timeout, output_format):
 
 def get_mds_info(r, timeout, output_format):
     info = dict()
-    info['dump'] = ceph_mon_command(r, 'mds dump', timeout, output_format)
-    info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
-    info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
+    info['dump'] = ceph_mon_command(r, 'fs dump', timeout, output_format)
     return info
 
 


### PR DESCRIPTION
…. Ceph MDS info on all filesystems can be captured by: ceph fs dump