### PR TITLE
Device health metrics added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ DEBUG:root:Cleaning up temporary directory: /tmp/tmpMpFk3n
 root@mon01:~#
 ```
 ### Gathering Device Health information
-By default  ``ceph-collect`` doesn't collect the device's health information. Use ``--device-health-metrics`` to enabled it.
+By default  ``ceph-collect`` doesn't collect the device's health information. Use ``--device-health-metrics`` to enable it.
 
 ``ceph-collect --device-heath-metrics``
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ INFO:root:Outputted Ceph information to /tmp/ceph-collect_20160729_150304.tar.gz
 DEBUG:root:Cleaning up temporary directory: /tmp/tmpMpFk3n
 root@mon01:~#
 ```
+### Gathering Device Health information
+By default  ``ceph-collect`` doesn't collect the device's health information. Use ``--device-health-metrics`` to enabled it.
+
+``ceph-collect --device-heath-metrics``
 
 ### One-liner
 If you want to run this tool without downloading it, you can run it directly using this one-liner:

--- a/ceph-collect
+++ b/ceph-collect
@@ -131,6 +131,7 @@ def get_osd_info(r, timeout, output_format):
 
 def get_mds_info(r, timeout, output_format):
     info = dict()
+    info['dump'] = ceph_mon_command(r, 'mds dump', timeout, output_format)
     info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
     info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
     return info

--- a/ceph-collect
+++ b/ceph-collect
@@ -88,11 +88,33 @@ def spawn(command, shell=True):
     return result.strip()
 
 
-def ceph_mon_command(r, command, timeout, output_format, **kargs):
+def ceph_mon_command(r, command, timeout, output_format, **kwargs):
     """
-    Using librados directly execute a command inside the Monitors
+    Using librados directly execute a command inside the Monitors.
+    
+    Args:
+        :param r:
+            The rados object connect to the cluster
+        :type r: ``rados.Rados``
+        :param command:
+            The command to be exected by the Mon
+        :type command: ``str``
+        :param timeout: 
+            The timeout for the request
+        :type  timeour: ``str``
+        :param output_format:
+        :type output_format: ``str``
+
+        :param \**kwargs:
+            the arguments to pass to the mon command 
+    
+    Example:
+        # 'ceph device get-health-metrics 130c0631-fa78-4697-9"
+        ceph_mon_command(r,"device get-health-metrics", dev_id="130c0631-fa78-4697-9")
     """
-    cmd = kargs.copy()
+
+    
+    cmd = kwargs.copy()
     cmd['prefix'] =  command
     cmd['format'] =  output_format
     _, buf, _ = r.mon_command(json.dumps(cmd), b'', timeout=timeout)
@@ -131,9 +153,17 @@ def get_osd_info(r, timeout, output_format):
 
 def get_mds_info(r, timeout, output_format):
     info = dict()
+    info['metadata'] = ceph_mon_command(r, 'mds metadata', timeout, output_format)
     info['dump'] = ceph_mon_command(r, 'mds dump', timeout, output_format)
-    info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
-    info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
+    if not info['dump']:
+        # New ceph version
+        info['dump'] = ceph_mon_command(r, 'fs dump', timeout, output_format)
+        # The standard output format is colorized, force to 'json-pretty'
+        info['status'] = ceph_mon_command(r, 'fs status', timeout, 'json-pretty')
+    else:
+        # Old ceph version
+        info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
+        info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
     return info
 
 def get_pg_info(r, timeout, output_format):
@@ -160,7 +190,8 @@ def get_device_info(r, timeout, output_format):
                     device['metrics'][key] = metrics[key]
         info['status'] = json.dumps( device_list, sort_keys=True, indent=4).encode('utf-8')
     else:
-        info['status'] = ''
+        LOGGER.info('Device health info is enabled, but it seems not supported by this ceph version')
+        info['status'] = b''
     return info
 
 def get_ceph_config(ceph_config):
@@ -261,8 +292,10 @@ if __name__ == '__main__':
                         default=False, help='Debug logging')
     PARSER.add_argument('--no-cleanup', action='store_false', dest='cleanup',
                         default=True, help='Clean up temporary directory')
-    PARSER.add_argument('--device-health-metrics', action='store_true',
-                        dest='device_health_metrics', default=False, help='Enable the collection of device health information')
+    PARSER.add_argument('--device-health-metrics', action='store_true',                       
+                        dest='device_health_metrics', default=False, 
+                        help='Enable the collection of device health information')
+                    
     ARGS = PARSER.parse_args()
 
     if ARGS.debug:

--- a/ceph-collect
+++ b/ceph-collect
@@ -88,11 +88,13 @@ def spawn(command, shell=True):
     return result.strip()
 
 
-def ceph_mon_command(r, command, timeout, output_format):
+def ceph_mon_command(r, command, timeout, output_format, **kargs):
     """
     Using librados directly execute a command inside the Monitors
     """
-    cmd = {'prefix': command, 'format': output_format}
+    cmd = kargs.copy()
+    cmd['prefix'] =  command
+    cmd['format'] =  output_format
     _, buf, _ = r.mon_command(json.dumps(cmd), b'', timeout=timeout)
     return buf
 
@@ -129,11 +131,9 @@ def get_osd_info(r, timeout, output_format):
 
 def get_mds_info(r, timeout, output_format):
     info = dict()
-    info['dump'] = ceph_mon_command(r, 'mds dump', timeout, output_format)
     info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
     info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
     return info
-
 
 def get_pg_info(r, timeout, output_format):
     info = dict()
@@ -142,13 +142,32 @@ def get_pg_info(r, timeout, output_format):
     info['dump_stuck'] = ceph_mon_command(r, 'pg dump_stuck', timeout, output_format)
     return info
 
+def get_device_info(r, timeout, output_format):
+    info = dict()
+    info['check_health'] = ceph_mon_command(r, 'device check-health', timeout, output_format)
+    device_list_str = ceph_mon_command(r, 'device ls', timeout, 'json')
+    if device_list_str:
+        device_list = json.loads(device_list_str)
+        for device in device_list:
+            metrics_str =  ceph_mon_command(r, 'device get-health-metrics' , timeout, output_format, devid=device['devid'])
+            device['metrics'] = {}
+            if metrics_str:
+                metrics = json.loads(metrics_str)
+                metrics_keys = [k for k in metrics.keys()]
+                metrics_keys.sort()
+                for key in metrics_keys[-1:]:
+                    device['metrics'][key] = metrics[key]
+        info['status'] = json.dumps( device_list, sort_keys=True, indent=4).encode('utf-8')
+    else:
+        info['status'] = ''
+    return info
 
 def get_ceph_config(ceph_config):
     return read_file(ceph_config)
 
 
 def collect_ceph_information(r, ceph_config, output_directory, timeout,
-                             output_format, cleanup=True):
+                             output_format, cleanup=True, device_health=False):
     tmpdir = tempfile.mkdtemp()
 
     LOGGER.debug('Using temporary directory %s', tmpdir)
@@ -164,6 +183,7 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
     files['version'] = spawn('ceph -v') + b'\n'
     files['versions'] = ceph_mon_command(r, 'versions', timeout, output_format)
     files['features'] = ceph_mon_command(r, 'features', timeout, output_format)
+    
     ##Add if to get around python2/python3 dependencies etc.
     if sys.version_info[0] == 3:
         files['fsid'] = bytes(r.get_fsid() + '\n', 'utf-8')
@@ -192,6 +212,10 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
     LOGGER.info('Gathering MDS information')
     for key, item in get_mds_info(r, timeout, output_format).items():
         files['mds_{0}'.format(key)] = item
+    if device_health:
+        LOGGER.info('Gathering Device Health information')
+        for key, item in get_device_info (r, timeout, output_format).items():
+            files['device_{0}'.format(key)] = item
 
     timestr = datetime.datetime.now().strftime("%Y%m%d_%H%I%S")
     tarball = '{0}/ceph-collect_{1}.tar.gz'.format(output_directory, timestr)
@@ -236,6 +260,8 @@ if __name__ == '__main__':
                         default=False, help='Debug logging')
     PARSER.add_argument('--no-cleanup', action='store_false', dest='cleanup',
                         default=True, help='Clean up temporary directory')
+    PARSER.add_argument('--device-health-metrics', action='store_true',
+                        dest='device_health_metrics', default=False, help='Enable the collection of device health information')
     ARGS = PARSER.parse_args()
 
     if ARGS.debug:
@@ -247,6 +273,7 @@ if __name__ == '__main__':
         collect_ceph_information(r=CNX, ceph_config=ARGS.ceph_config,
                                  output_directory=ARGS.output_dir,
                                  timeout=ARGS.timeout, cleanup=ARGS.cleanup,
+                                 device_health=ARGS.device_health_metrics,
                                  output_format=ARGS.output_format)
         RETURN_VALUE = 0
     except (rados.Error,


### PR DESCRIPTION
When it is executed as ``ceph-collect --device-health-metrics`` 
I  add 2 new files in the tar 

1. `device_check_health` with the output of `ceph device check-health`
2. `device_status` with a json structure like this one
> 
>           .....
>           {
>               "daemons": [
>                   "osd.6"
>               ],
>               "devid": "0c218f90-931f-4d20-8",
>               "location": [
>                   {
>                       "dev": "vdb",
>                       "host": "mon3",
>                       "path": "/dev/disk/by-path/pci-0000:00:05.0"
>                   }
>               ],
>               "metrics": {
>                   "20220203-000856": {
>                       .....
>                   }
>               }
>           },
>         ...


      Only the last metric per device is included.

