### PR TITLE
Gathering MDS: Fix for luminous or later versions.

### DIFF
--- a/ceph-collect
+++ b/ceph-collect
@@ -129,9 +129,19 @@ def get_osd_info(r, timeout, output_format):
 
 def get_mds_info(r, timeout, output_format):
     info = dict()
+    info['metadata'] = ceph_mon_command(r, 'mds metadata', timeout, output_format)
     info['dump'] = ceph_mon_command(r, 'mds dump', timeout, output_format)
-    info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
-    info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
+    if not info['dump']:
+        # New ceph version
+        LOGGER.debug("Gathering MDS: Luminous or newer version")
+        info['dump'] = ceph_mon_command(r, 'fs dump', timeout, output_format)
+        # The standard output format is colorized, force to 'json-pretty'
+        info['status'] = ceph_mon_command(r, 'fs status', timeout, 'json-pretty')
+    else:
+        # Old ceph version
+        LOGGER.debug("Gathering MDS: Mimic or previous version")
+        info['stat'] = ceph_mon_command(r, 'mds stat', timeout, output_format)
+        info['map'] = ceph_mon_command(r, 'mds getmap', timeout, output_format)
     return info
 
 


### PR DESCRIPTION
Version after Luminous don't support `ceph mds stat` and `ceph mds map`,  they have been replaced with  `ceph fs dump`.
new files:

1. `mds_status`  It is the output os `ceph fs status --format=json-pretty`. The json-pretty format must be used because the default plain output is "colorized".
2. `mds_metadata` It is the output os `ceph mds metadata`
