### PR TITLE
Config filters

### DIFF
--- a/ceph-collect
+++ b/ceph-collect
@@ -248,7 +248,6 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
                         if is_conffile:
                             lines[index] = line[:line.rfind("=")] + ' = ' + FILTER_PLACEHOLDER 
                         else:
-                            print(line)
                             lines[index] = line.replace(line.split()[3], FILTER_PLACEHOLDER)
             data='\n'.join(lines)
 

--- a/ceph-collect
+++ b/ceph-collect
@@ -26,10 +26,12 @@ CEPH_CONFIG_FILE = '/etc/ceph/ceph.conf'
 CEPH_TIMEOUT = 10
 
 DEFAULT_CONFIG_FILTERS = [
-    'password',
-    'key',
-    'cert'
+    '(?i)password',
+    '(?i)key',
+    '(?i)cert'
 ]
+FILTER_PLACEHOLDER = "** HIDDEN **"
+
 # Logging configuration
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
@@ -210,8 +212,12 @@ def get_ceph_config(ceph_config):
 
 def collect_ceph_information(r, ceph_config, output_directory, timeout,
                              output_format, cleanup=True, device_health=False,
-                             custom_config_filters=[]):
-    def filter_config(data, mode):
+                            custom_config_filters=[],log_config=False):
+    
+    config_filters=DEFAULT_CONFIG_FILTERS
+    config_filters.extend(custom_config_filters) 
+    
+    def filter_config(data, mode, is_conffile=False):
         """
         It purges the configuration
         Args:
@@ -223,30 +229,36 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
                     * 'plain' 
                     * 'json'   
             :type mode: ``str``
+            :param is_conffile:
+                True is data is from "ceph.conf" (INI file)
+            :type is_conffile: ``bool``
         Return:
             bytes
         
         """
-        config_filters=DEFAULT_CONFIG_FILTERS
-        config_filters.extend(custom_config_filters) 
         if mode == 'plain':
             if type(data) == bytes:
                 data=data.decode('utf-8')
 
             lines=data.splitlines()
             for patter in config_filters:
-                for index in range(len(lines)-1,-1,-1):
-                    if bool(re.search(patter, lines[index])):
-                        del lines[index]
+                for index in range(len(lines)-1, -1, -1):
+                    line=lines[index]
+                    if bool(re.search(patter, line)):
+                        if is_conffile:
+                            lines[index] = line[:line.rfind("=")] + ' = ' + FILTER_PLACEHOLDER 
+                        else:
+                            print(line)
+                            lines[index] = line.replace(line.split()[3], FILTER_PLACEHOLDER)
             data='\n'.join(lines)
 
         elif mode in ('json', 'json-pretty'):
             js= json.loads(data)
             for patter in config_filters:
-                for index in range(len(js)-1 ,-1, -1):
+                for index in range(len(js)-1, -1, -1):
                     for key in ('name', 'section', 'value'):
                         if bool(re.search(patter, js[index][key])):
-                            del js[index]
+                            js[index]['value']=FILTER_PLACEHOLDER
                             break
             if mode == 'json':
                 data = json.dumps(js)
@@ -279,20 +291,32 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
         files['fsid'] = bytes(r.get_fsid() + '\n', 'utf-8')
         files['ceph.conf'] = filter_config(
                 get_ceph_config(ceph_config), 
-                'plain'
+                'plain',
+                True
         )
     else:
         files['fsid'] = str(r.get_fsid()) + '\n'
         files['ceph.conf'] = str(
             filter_config(
                 get_ceph_config(ceph_config), 
-                'plain'
+                'plain',
+                True
             )
         )
     files['config'] = filter_config(
         ceph_mon_command(r, 'config dump', timeout, output_format),
-        output_format
+        output_format,
+        False
     )
+    if log_config: 
+        LOGGER.info('==== ceph.conf ======')
+        for line in files['ceph.conf'] .splitlines():
+            writemessage = " - " + line.decode('utf-8') 
+            LOGGER.info(str(writemessage))
+        LOGGER.info('====== config ======')
+        for line in files['config'] .splitlines():
+            writemessage = " - " + line.decode('utf-8')
+            LOGGER.info(str(writemessage))
 
     LOGGER.info('Gathering Health information')
     for key, item in get_health_info(r, timeout, output_format).items():
@@ -370,6 +394,9 @@ if __name__ == '__main__':
                         dest='custom_config_filter',
                         help='Custom filter (python regex) for purging config dump. '
                         )
+    PARSER.add_argument('--log-gathered-config', action='store_true',
+                        dest='log_gathered_config', default=False,
+                        help='Log on INFO the config after the purge')
     ARGS = PARSER.parse_args()
 
     if ARGS.debug:
@@ -383,7 +410,8 @@ if __name__ == '__main__':
                                  timeout=ARGS.timeout, cleanup=ARGS.cleanup,
                                  device_health=ARGS.device_health_metrics,
                                  custom_config_filters=ARGS.custom_config_filter or [],
-                                 output_format=ARGS.output_format)
+                                 output_format=ARGS.output_format,
+                                 log_config=ARGS.log_gathered_config)
         RETURN_VALUE = 0
     except (rados.Error,
             tarfile.TarError,

--- a/ceph-collect
+++ b/ceph-collect
@@ -217,7 +217,7 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
     config_filters=DEFAULT_CONFIG_FILTERS
     config_filters.extend(custom_config_filters) 
     
-    def filter_config(data, mode, is_conffile=False):
+    def filter_config(data, mode, is_conffile):
         """
         It purges the configuration
         Args:
@@ -230,7 +230,7 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
                     * 'json'   
             :type mode: ``str``
             :param is_conffile:
-                True is data is from "ceph.conf" (INI file)
+                True if data is from "ceph.conf"
             :type is_conffile: ``bool``
         Return:
             bytes
@@ -241,14 +241,23 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
                 data=data.decode('utf-8')
 
             lines=data.splitlines()
+            if not is_conffile:
+                # find the position of the VALUE Column
+                config_value_start=lines[0].rfind("VALUE")
+                config_value_end=lines[0].rfind("RO")
+
             for patter in config_filters:
-                for index in range(len(lines)-1, -1, -1):
+                for index in range(len(lines)-1, 0, -1):
                     line=lines[index]
                     if bool(re.search(patter, line)):
                         if is_conffile:
+                            # replace from '=' to end of line with FILTER_PLACEHOLDER 
                             lines[index] = line[:line.rfind("=")] + ' = ' + FILTER_PLACEHOLDER 
                         else:
-                            lines[index] = line.replace(line.split()[3], FILTER_PLACEHOLDER)
+                            # replace the VALUE column with FILTER_PLACEHOLDER
+                            lines[index] = line[:config_value_start] +  \
+                                FILTER_PLACEHOLDER + " " + \
+                                line[config_value_end]
             data='\n'.join(lines)
 
         elif mode in ('json', 'json-pretty'):


### PR DESCRIPTION
The predefined filter are case insensitive.
Filtered data is not purged but Masked with `** HIDDEN **`
Configs can be logged with `--log-gathered-config`

```
ubuntu@mon1:~/ceph-collect$ ./ceph-collect --log-gathered-config --config-filter rgw
INFO:root:Gathering overall system information
No LSB modules are available.
INFO:root:Gathering overall Ceph information
INFO:root:==== ceph.conf ======
INFO:root: - # Please do not change this file directly since it is managed by Ansible and will be overwritten
INFO:root: - [global]
INFO:root: - cluster network = 172.16.4.0/24
INFO:root: - fsid = 35927808-bc77-444c-8f40-489e78c474fa
INFO:root: - mon host = [v2:172.16.4.45:3300,v1:172.16.4.45:6789],[v2:172.16.4.113:3300,v1:172.16.4.113:6789],[v2:172.16.4.130:3300,v1:172.16.4.130:6789]
INFO:root: - mon initial members = mon1,mon2,mon3
INFO:root: - osd pool default crush rule = -1
INFO:root: - public network = 172.16.4.0/24
INFO:root: -
INFO:root: - [osd]
INFO:root: - bluestore_min_alloc_size_hdd = 4096
INFO:root: -
INFO:root: - [mgr]
INFO:root: - mgr/alerts/smtp_password  = ** HIDDEN **
INFO:root: - mgr/alerts/smtp_PaSSwOrd  = ** HIDDEN **
INFO:root:====== config ======
INFO:root: - WHO             MASK  LEVEL     OPTION                                          VALUE       RO
INFO:root: - global                advanced  mon_allow_pool_delete                           true
INFO:root: - global                advanced  mon_max_pg_per_osd                              2000
INFO:root: - global                advanced  osd_pool_default_pg_autoscale_mode              warn
INFO:root: -   mon                 advanced  mon_warn_on_insecure_global_id_reclaim          false
INFO:root: -   mon                 advanced  mon_warn_on_insecure_global_id_reclaim_allowed  false
INFO:root: -   mgr                 advanced  mgr/alerts/smtp_password                        ** HIDDEN **
INFO:root: -   mgr                 advanced  mgr/alerts/smtp_user                            test
INFO:root: -   mgr                 advanced  mgr/balancer/active                             true
INFO:root: -   mgr                 advanced  mgr/balancer/mode                               upmap
INFO:root: -   mgr                 advanced  mgr/influx/password                             ** HIDDEN **    *
INFO:root: -   mgr                 advanced  mgr/influx/username                             admin123    *
INFO:root: -   mgr                 basic     target_max_misplaced_ratio                      0.200000
INFO:root: -   osd                 advanced  osd_max_backfills                               12
INFO:root: -   osd                 basic     osd_memory_target                               1073741824
INFO:root: -   osd                 advanced  osd_recovery_max_active                         16
INFO:root: -   osd                 advanced  osd_recovery_sleep_hdd                          0.000000
INFO:root: -   osd                 advanced  osd_scrub_during_recovery                       true
INFO:root: -     client.rgw        basic     rgw_dynamic_resharding                          ** HIDDEN **
INFO:root: -     client.rgw        advanced  rgw_max_dynamic_shards                          ** HIDDEN **
INFO:root: -     client.rgw        basic     rgw_max_objs_per_shard                          ** HIDDEN **
INFO:root: -     client.rgw        advanced  rgw_reshard_thread_interval                     ** HIDDEN **
INFO:root: -     client.rgw        advanced  rgw_safe_max_objects_per_shard                  ** HIDDEN **
INFO:root: -     client.rgw        advanced  rgw_shard_warning_threshold                     ** HIDDEN **
INFO:root:Gathering Health information
INFO:root:Gathering MON information
INFO:root:Gathering OSD information
INFO:root:Gathering PG information
INFO:root:Gathering MDS information
INFO:root:Outputted Ceph information to /tmp/ceph-collect_20220218_130143.tar.gz
```