### PR TITLE
os info for systems without lsb_release

### DIFF
--- a/ceph-collect
+++ b/ceph-collect
@@ -157,7 +157,10 @@ def collect_ceph_information(r, ceph_config, output_directory, timeout,
 
     LOGGER.info('Gathering overall system information')
     files['uname'] = spawn('uname -a') + b'\n'
-    files['lsb_release'] = spawn('lsb_release -a') + b'\n'
+    lsb_release = spawn('lsb_release -a')
+    if(len(lsb_release)==0):
+        lsb_release = spawn('cat /etc/*-release')
+    files['lsb_release'] = lsb_release + b'\n'
 
     LOGGER.info('Gathering overall Ceph information')
     files['status'] = ceph_mon_command(r, 'status', timeout, output_format)


### PR DESCRIPTION
If the system doesn't have lsb_release binary, just cat everything under '/etc/*-release' instead.